### PR TITLE
[Bug Fix] Inserting nil value into NSDictionary may cause exception.

### DIFF
--- a/NSURL+QueryDictionary/NSURL+QueryDictionary.m
+++ b/NSURL+QueryDictionary/NSURL+QueryDictionary.m
@@ -22,7 +22,7 @@ static NSString *const kFragmentBegin   = @"#";
     if (components.count == 2) {
       NSString *key = [components[0] stringByRemovingPercentEncoding];
       NSString *value = [components[1] stringByRemovingPercentEncoding];
-      mute[key] = value;
+      mute[key] = value ? value : @"";
     }
   }
   return mute.count ? mute.copy : nil;

--- a/UnitTests/UnitTests.m
+++ b/UnitTests/UnitTests.m
@@ -75,6 +75,11 @@
                         @"Did not create correctly formatted URL");
 }
 
+- (void) testShouldHandleEmptyValue {
+    NSString *urlString = @"http://www.foo.com?aKey=";
+    XCTAssertEqual([URL(urlString) queryDictionary][@"aKey"], @"", @"Value should be empty string");
+}
+
 @end
 
 #undef URL


### PR DESCRIPTION
Hi, I'm using your library and made a little improvement for it. When a NSURL like `http://foo.com?aKey=` is given and call `-queryDictionary`, it would crash for inserting nil value into dictionary, I fixed that with casting that nil value into empty string and wrote a test case for that, please take a look.
