### PR TITLE
Update NSURL+QueryDictionary.podspec

### DIFF
--- a/NSURL+QueryDictionary.podspec
+++ b/NSURL+QueryDictionary.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license       = { :type => 'MIT', :file => 'LICENSE' }
   s.author        = { "Jonathan Crooke" => "jon.crooke@gmail.com" }
   s.source        = { :git => "https://github.com/itsthejb/NSURL-QueryDictionary.git", :tag => "v" + s.version.to_s }
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '6.1'
   s.osx.deployment_target = '10.8'
   s.source_files  = s.name + '/*.{h,m}'
   s.frameworks    = 'Foundation'


### PR DESCRIPTION
It works fine on iOS 6.1 - we tested it and there are no warnings or errors.
