### PR TITLE
[watchos] Add support for watchOS 2

### DIFF
--- a/NSURL+QueryDictionary.podspec
+++ b/NSURL+QueryDictionary.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.source        = { :git => "https://github.com/itsthejb/NSURL-QueryDictionary.git", :tag => "v" + s.version.to_s }
   s.ios.deployment_target = '6.1'
   s.osx.deployment_target = '10.8'
+  s.watchos.deployment_target = '2.0'
   s.source_files  = s.name + '/*.{h,m}'
   s.frameworks    = 'Foundation'
   s.requires_arc  = true


### PR DESCRIPTION
Adds a line to the .podspec file to allow this pod to support targets with platform `watchos`.
