### PR TITLE
FIX: If HTTP URL only contains fragment. When I call ‘uq_URLByAppendi…

### DIFF
--- a/NSURL+QueryDictionary/NSURL+QueryDictionary.m
+++ b/NSURL+QueryDictionary/NSURL+QueryDictionary.m
@@ -37,13 +37,16 @@ static NSString *const kFragmentBegin       = @"#";
   if (newQuery.length) {
     NSArray *queryComponents = [self.absoluteString componentsSeparatedByString:kQueryBegin];
     if (queryComponents.count) {
-      return [NSURL URLWithString:
-              [NSString stringWithFormat:@"%@%@%@%@%@",
-               queryComponents[0],                      // existing url
-               kQueryBegin,
-               newQuery,
-               self.fragment.length ? kFragmentBegin : @"",
-               self.fragment.length ? self.fragment : @""]];
+      NSArray *fragmentComponents = [queryComponents[0] componentsSeparatedByString:kFragmentBegin];
+      if (fragmentComponents.count) {
+        return [NSURL URLWithString:
+                [NSString stringWithFormat:@"%@%@%@%@%@",
+                 fragmentComponents[0],                      // existing url
+                 kQueryBegin,
+                 newQuery,
+                 self.fragment.length ? kFragmentBegin : @"",
+                 self.fragment.length ? self.fragment : @""]];
+      }
     }
   }
   return self;


### PR DESCRIPTION
…ngQueryDictionary’, it returns nil.

e.g.
NSURL *url = [NSURL URLWithString:@"https://test.com#test1"];
url = [url uq_URLByAppendingQueryDictionary:@{@"key" : @"value"}];

Then, url is nil.