### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,50 +20,50 @@ The methods returning URL instances have `withSortedKeys:` partner methods that 
 
 Queries with empty values are converted to `NSNull` and vice versa as of `v0.0.5`.
 
-##Version history
+## Version history
 
-###v1.2.0
+### v1.2.0
  * Adds support for WatchOS targets. Thanks to [Stedman Wilson](https://github.com/sandimas2688) and [Orta](https://github.com/orta).
  * Necessary project updates
 
-###v1.1.0
+### v1.1.0
 
 * Now has methods to create URL copies with the query removed, or replaced with a specified query dictionary.
 
-###v1.0.3
+### v1.0.3
 
 Bug fixes courtesy of [Jan Berkel](https://github.com/jberkel), [Elliot Chance](https://github.com/elliotchance) and [Grzegorz Nowicki](https://github.com/wikia-gregor). [1](https://github.com/itsthejb/NSURL-QueryDictionary/pull/6), [2](https://github.com/itsthejb/NSURL-QueryDictionary/pull/7), [3](https://github.com/itsthejb/NSURL-QueryDictionary/pull/5).
 
-###v1.0.2
+### v1.0.2
 
 * Added category prefixes at the suggestion of [Mike Abdullah](https://github.com/mikeabdullah).
 * Now compiles for OSX 10.8, with thanks to [Elliot Chance](https://github.com/elliotchance).
 
-###v0.0.7
+### v0.0.7
 
 Fixed a potential issue/static analyser false positive with thanks to [Adam Lickel](https://github.com/lickel).
 
-###v0.0.6
+### v0.0.6
 
 Added optional flag to sort the dictionary's keys alphabetically when generating the URL. This makes the generated URLs more deterministic, which helps (for example) if you are running unit tests to inspect your URLs and would like to test the absolute string, rather than having to recreate a query dictionary.
 
-###v0.0.5
+### v0.0.5
 
 Covered an additional empty value case - URL query component has separator, but empty value.
 
-###v0.0.4
+### v0.0.4
 
 Added handling for keys with no value, empty value or `NSNull`.
 
-###v0.0.3
+### v0.0.3
 
 Split the query string parsing components out into `NSString` and `NSDictionary` categories for additional flexibility.
 
-###v0.0.2
+### v0.0.2
 
 Added support for dictionary keys other than NSString. Currently just uses `-description`, but this is ok for `NSNumber` and `NSDate` and a few others, so may be sufficient.
 
-###v0.0.1
+### v0.0.1
 
 Initial release.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
